### PR TITLE
Set JSON-LD expansion policy as relaxed instead of strict

### DIFF
--- a/ssi-json-ld/src/lib.rs
+++ b/ssi-json-ld/src/lib.rs
@@ -520,7 +520,7 @@ where
         expand_context,
         // VC HTTP API Test Suite expect properties to not be silently dropped.
         // More info: https://github.com/timothee-haudebourg/json-ld/issues/13
-        expansion_policy: json_ld::expansion::Policy::Strict,
+        expansion_policy: json_ld::expansion::Policy::Relaxed,
         ..Default::default()
     };
 


### PR DESCRIPTION
Workaround for key expansion error during presentation until we construct a RSS proof context.